### PR TITLE
Replace the dev theme directory with the prod theme directory when building for production.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 2.0.1
 - Fix Travis-CI not executing nightly build jobs. See [#540](https://github.com/wprig/wprig/pull/540). Props @felixarntz.
 - Add automated tests for the gulp task that builds the production theme. See [#579](https://github.com/wprig/wprig/pull/579). Props @ataylorme.
+- Replaces the dev theme directory with the prod theme directory when building for production. Adds corresponding gulp tests for PHP, CSS and JS files. See [#559](https://github.com/wprig/wprig/issues/559). Props @ataylorme
 
 ## 2.0.0
 - Full refactor of dev file structure. See [#133](https://github.com/wprig/wprig/pull/133). Props @ataylorme.

--- a/gulp/constants.js
+++ b/gulp/constants.js
@@ -17,6 +17,7 @@ import {
 
 // Root path is where npm run commands happen
 export const rootPath = process.cwd();
+export const devThemeDirName = rootPath.replace(/\/$/, '').split('/').pop();
 
 export const gulpPath = `${ rootPath }/gulp`;
 
@@ -30,6 +31,7 @@ const config = getThemeConfig();
 
 // directory for the production theme
 export const prodThemePath = path.normalize( `${ rootPath }/../${ config.theme.slug }` );
+export const prodThemeDirName = prodThemePath.replace(/\/$/, '').split('/').pop();
 
 // directory for assets (CSS, JS, images)
 export const assetsDir = `${ rootPath }/assets`;

--- a/gulp/constants.js
+++ b/gulp/constants.js
@@ -76,6 +76,7 @@ const paths = {
 			`!${ rootPath }/optional/**/*.*`,
 			`!${ rootPath }/tests/**/*.*`,
 			`!${ rootPath }/vendor/**/*.*`,
+			`!${ rootPath }/gulp/**/*.*`,
 		],
 		dest: `${ rootPath }/`,
 	},

--- a/gulp/tests/prod-build/prod-build.test.js
+++ b/gulp/tests/prod-build/prod-build.test.js
@@ -134,3 +134,49 @@ test( 'PHP files in the production theme do not contain default strings', ( done
 
 	done();
 } );
+
+test( 'CSS files in the production theme do not contain default strings', ( done ) => {
+	// Get the array of CSS file paths
+	const filePathsArray = glob.sync( prodThemePath + '/**/*.css' );
+	let failMessage;
+	// Loop over each one
+	filePathsArray.forEach( ( filePath ) => {
+		// Ensure that it doesn't have any default strings.
+		const fileContents = fs.readFileSync(
+			filePath,
+			{ encoding: 'utf-8' }
+		);
+		Object.keys( nameFieldDefaults ).forEach( ( key ) => {
+			failMessage = `The file ${ filePath } contains the default string ${ nameFieldDefaults[ key ] }`;
+			expect( fileContents, failMessage ).not.toContain( nameFieldDefaults[ key ] );
+		} );
+		// And that it doesn't contain the dev theme directory
+		failMessage = `The file ${ filePath } contains the dev theme directory ${ devThemeDirName }`;
+		expect( fileContents, failMessage ).not.toContain( devThemeDirName );
+	} );
+
+	done();
+} );
+
+test( 'JS files in the production theme do not contain default strings', ( done ) => {
+	// Get the array of JS file paths
+	const filePathsArray = glob.sync( prodThemePath + '/**/*.js' );
+	let failMessage;
+	// Loop over each one
+	filePathsArray.forEach( ( filePath ) => {
+		// Ensure that it doesn't have any default strings.
+		const fileContents = fs.readFileSync(
+			filePath,
+			{ encoding: 'utf-8' }
+		);
+		Object.keys( nameFieldDefaults ).forEach( ( key ) => {
+			failMessage = `The file ${ filePath } contains the default string ${ nameFieldDefaults[ key ] }`;
+			expect( fileContents, failMessage ).not.toContain( nameFieldDefaults[ key ] );
+		} );
+		// And that it doesn't contain the dev theme directory
+		failMessage = `The file ${ filePath } contains the dev theme directory ${ devThemeDirName }`;
+		expect( fileContents, failMessage ).not.toContain( devThemeDirName );
+	} );
+
+	done();
+} );

--- a/gulp/tests/prod-build/prod-build.test.js
+++ b/gulp/tests/prod-build/prod-build.test.js
@@ -17,6 +17,7 @@ import {
 	rootPath,
 	nameFieldDefaults,
 	paths,
+	devThemeDirName,
 } from '../../constants';
 
 test( 'gulp runs in production mode', ( done ) => {
@@ -103,6 +104,32 @@ test( 'string replacement files to copy exist in the production theme and do not
 			failMessage = `The file ${ filePath } contains the default string ${ nameFieldDefaults[ key ] }`;
 			expect( fileContents, failMessage ).not.toContain( nameFieldDefaults[ key ] );
 		} );
+		// Or that it doesn't contain the dev theme directory
+		failMessage = `The file ${ filePath } contains the dev theme directory ${ prodThemePath }`;
+		expect( fileContents, failMessage ).not.toContain( prodThemePath );
+	} );
+
+	done();
+} );
+
+test( 'PHP files in the production theme do not contain default strings', ( done ) => {
+	// Get the array of PHP file paths
+	const filePathsArray = glob.sync( prodThemePath + '/**/*.php' );
+	let failMessage;
+	// Loop over each one
+	filePathsArray.forEach( ( filePath ) => {
+		// Ensure that it doesn't have any default strings.
+		const fileContents = fs.readFileSync(
+			filePath,
+			{ encoding: 'utf-8' }
+		);
+		Object.keys( nameFieldDefaults ).forEach( ( key ) => {
+			failMessage = `The file ${ filePath } contains the default string ${ nameFieldDefaults[ key ] }`;
+			expect( fileContents, failMessage ).not.toContain( nameFieldDefaults[ key ] );
+		} );
+		// And that it doesn't contain the dev theme directory
+		failMessage = `The file ${ filePath } contains the dev theme directory ${ devThemeDirName }`;
+		expect( fileContents, failMessage ).not.toContain( devThemeDirName );
 	} );
 
 	done();

--- a/gulp/tests/prod-build/prod-build.utils.js
+++ b/gulp/tests/prod-build/prod-build.utils.js
@@ -14,4 +14,8 @@ export const filesToMock = [
 		mock: `${ gulpTestPath }/prod-build/config.local.json`,
 		dest: `${ rootPath }/config/config.local.json`,
 	},
+	{
+		mock: `${ gulpTestPath }/prod-build/prod-test.php`,
+		dest: `${ rootPath }/template-parts/prod-test.php`,
+	},
 ];

--- a/gulp/tests/prod-build/prod-test.php
+++ b/gulp/tests/prod-build/prod-test.php
@@ -1,0 +1,1 @@
+<amp-img src="../wp-content/themes/wprig/assets/images/placeholder.svg" width="1" height="1" layout="responsive"></amp-img>

--- a/gulp/utils.js
+++ b/gulp/utils.js
@@ -21,6 +21,8 @@ import {
 	prodThemePath,
 	isProd,
 	rootPath,
+	devThemeDirName,
+	prodThemeDirName,
 } from './constants';
 
 export const getDefaultConfig = () => require( `${ rootPath }/config/config.default.json` );
@@ -76,7 +78,7 @@ export function getStringReplacementTasks() {
 	// Get a copy of the config
 	const config = getThemeConfig( isProd );
 
-	const stringReplacementTasks = Object.keys( nameFieldDefaults ).map( ( nameField ) => {
+	let stringReplacementTasks = Object.keys( nameFieldDefaults ).map( ( nameField ) => {
 		return gulpPlugins.stringReplace(
 			// Backslashes must be double escaped for regex
 			nameFieldDefaults[ nameField ].replace( /\\/g, '\\\\' ),
@@ -89,6 +91,21 @@ export function getStringReplacementTasks() {
 			}
 		);
 	} );
+
+	if ( isProd ) {
+		stringReplacementTasks.push(
+			gulpPlugins.stringReplace(
+				devThemeDirName,
+				prodThemeDirName,
+				{
+					logs: {
+						enabled: false,
+					},
+					searchValue: 'regex',
+				}
+			)
+		);
+	}
 
 	// Return a single stream containing all the
 	// string replacement tasks

--- a/package-lock.json
+++ b/package-lock.json
@@ -5400,9 +5400,9 @@
       }
     },
     "eslint-utils": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.0.tgz",
-      "integrity": "sha512-7ehnzPaP5IIEh1r1tkjuIrxqhNkzUJa9z3R92tLJdZIVdWaczEhr3EbhGtsMrVxi1KeR8qA7Off6SWc5WNQqyQ==",
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.2.tgz",
+      "integrity": "sha512-eAZS2sEUMlIeCjBeubdj45dmBHQwPHWyBcT1VSYB7o9x9WRRqKxyUoiXlRjyAwzN7YEzHJlYg0NmzDRWx6GP4Q==",
       "dev": true,
       "requires": {
         "eslint-visitor-keys": "^1.0.0"

--- a/package.json
+++ b/package.json
@@ -120,5 +120,6 @@
     "lint": "eslint assets/js/src/",
     "lint:gulp": "eslint gulp/",
     "lint:gulp:fix": "eslint --fix gulp/"
-  }
+  },
+  "dependencies": {}
 }


### PR DESCRIPTION
## Description
<!-- Add the issue number this pull request addresses: -->
Addresses issue #559. Replaces the dev theme directory with the prod theme directory when building for production. Adds corresponding gulp tests for PHP, CSS and JS files.
<!-- Please describe your pull request. -->

## List of changes
<!-- Please describe what was changed/added. -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] This pull request relates to a ticket.
- [x] This code is tested.
- [ ] This change has been added to CHANGELOG.md
- [x] I want my code added to WP Rig.